### PR TITLE
#163556785: implement endpoint for updating party name

### DIFF
--- a/server/controllers/PartyController.js
+++ b/server/controllers/PartyController.js
@@ -49,6 +49,30 @@ class PartyController {
       data: [...parties],
     });
   }
+
+  static updatePartyName(req, res, next) {
+    const id = parseInt(req.params.id, 10);
+    const { name } = req.body;
+    let partyIndex;
+
+    parties.filter((party, index) => {
+      if (party.id === id) {
+        partyIndex = index;
+      }
+    });
+
+    if (partyIndex === undefined) {
+      const error = new Error('No party with such id');
+      error.status = 404;
+      return next(error);
+    }
+
+    parties[partyIndex].name = name;
+    return res.status(200).json({
+      status: 200,
+      data: [{ message: 'successfully updated' }],
+    });
+  }
 }
 
 export default PartyController;

--- a/server/middleware/ErrorMiddleware.js
+++ b/server/middleware/ErrorMiddleware.js
@@ -7,7 +7,7 @@ class ErrorMiddleware {
 
   /* eslint-disable no-unused-vars */
   static errorHandler(err, req, res, next) {
-    const statusCode = err.status !== 200 ? err.status : 500;
+    const statusCode = err.status || 500;
     res.status(statusCode);
 
     res.json({

--- a/server/models/parties.js
+++ b/server/models/parties.js
@@ -14,7 +14,7 @@ const parties = [
     acronym: 'AD',
   },
   {
-    id: 1,
+    id: 3,
     name: 'All Progressives Congress',
     hqAddress: '12 Banire Street, Egbeda, Lagos',
     logoUrl: 'https://buzznigeria.com/wp-content/uploads/2016/10/PDP-logo.jpg',

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,10 +1,10 @@
 import express from 'express';
 import homeRoute from './homeRoute';
-import partiesroute from './partiesRoute';
+import partiesRoute from './partiesRoute';
 
 const router = express.Router();
 
 router.use('/', homeRoute);
-router.use('/parties', partiesroute);
+router.use('/parties', partiesRoute);
 
 export default router;

--- a/server/routes/partiesRoute.js
+++ b/server/routes/partiesRoute.js
@@ -8,5 +8,6 @@ const router = express.Router();
 router.post('/', uploadLogo, Validate.validateParty, PartyController.createParty);
 router.get('/:id', Validate.validateId, PartyController.getOneParty);
 router.get('/', PartyController.getAllParties);
+router.patch('/:id/name', Validate.validateId, PartyController.updatePartyName);
 
 export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import logger from 'morgan';
+import bodyParser from 'body-parser';
 
 import routes from './routes';
 import ErrorMiddleware from './middleware/ErrorMiddleware';
@@ -12,8 +13,10 @@ const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(logger('dev'));
-app.use('/api/v1', routes);
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
 
+app.use('/api/v1', routes);
 
 app.use(ErrorMiddleware.notFound);
 app.use(ErrorMiddleware.errorHandler);

--- a/server/test/party.test.js
+++ b/server/test/party.test.js
@@ -130,3 +130,33 @@ describe('GET /api/v1/parties', () => {
       });
   });
 });
+
+describe('PATCH /api/v1/parties/:id/name', () => {
+  it('should update a party name', (done) => {
+    chai.request(server).patch('/api/v1/parties/1/name').send({
+      name: 'Republican',
+    }).end((err, res) => {
+      should.not.exist(err);
+      res.status.should.equal(200);
+      done();
+    });
+  });
+
+  it('should not update a party name if the id is not a number', (done) => {
+    chai.request(server).patch('/api/v1/parties/mmmm/name').send({
+      name: 'Republican',
+    }).end((err, res) => {
+      res.status.should.equal(400);
+      done();
+    });
+  });
+
+  it('should not update a party name if the id is not found', (done) => {
+    chai.request(server).patch('/api/v1/parties/20/name').send({
+      name: 'Republican',
+    }).end((err, res) => {
+      res.status.should.equal(404);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
create an endpoint for admin to update the name of a specific party
#### Description of Task to be completed?
-  add update one part method to party controller
- write tests for this endpoint
#### How should this be manually tested?
- clone the GitHub repo
- checkout branch ``ft-admin-edit-party-name-163556785``
- run ``npm install`` and ``npm run``
- on POSTMAN, send a PATCH request to ``/api/v1/parties/:id/name``., Send the request body to contain the new party name. The response should be a successful operation message.
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163556785