### PR TITLE
#163556842 implement an endpoint for delete party

### DIFF
--- a/server/controllers/PartyController.js
+++ b/server/controllers/PartyController.js
@@ -73,6 +73,27 @@ class PartyController {
       data: [{ message: 'successfully updated' }],
     });
   }
+
+  static deleteParty(req, res, next) {
+    const id = parseInt(req.params.id, 10);
+    let partyIndex;
+
+    const partyFound = parties.filter((party, index) => {
+      if (party.id === id) {
+        partyIndex = index;
+      }
+    });
+    if (partyIndex === undefined) {
+      const error = new Error('No party with such id');
+      error.status = 404;
+      return next(error);
+    }
+    parties.splice(partyIndex, 1);
+    return res.status(200).json({
+      status: 200,
+      data: [{ message: 'successfully deleted' }],
+    });
+  }
 }
 
 export default PartyController;

--- a/server/routes/partiesRoute.js
+++ b/server/routes/partiesRoute.js
@@ -9,5 +9,6 @@ router.post('/', uploadLogo, Validate.validateParty, PartyController.createParty
 router.get('/:id', Validate.validateId, PartyController.getOneParty);
 router.get('/', PartyController.getAllParties);
 router.patch('/:id/name', Validate.validateId, PartyController.updatePartyName);
+router.delete('/:id', Validate.validateId, PartyController.deleteParty);
 
 export default router;

--- a/server/test/party.test.js
+++ b/server/test/party.test.js
@@ -160,3 +160,32 @@ describe('PATCH /api/v1/parties/:id/name', () => {
     });
   });
 });
+
+describe('DELETE /api/v1/parties', () => {
+  it('should delete a single party', (done) => {
+    chai.request(server).del('/api/v1/parties/1')
+      .end((err, res) => {
+        should.not.exist(err);
+        res.status.should.eql(200);
+        done();
+      });
+  });
+
+  it('should not delete a party if the id is not valid', (done) => {
+    chai.request(server).del('/api/v1/parties/mnbvn')
+      .end((err, res) => {
+        res.status.should.eql(400);
+        res.body.error.should.eql('Invalid id');
+        done();
+      });
+  });
+
+  it('should return an error if there is no party with the id', (done) => {
+    chai.request(server).del('/api/v1/parties/98')
+      .end((err, res) => {
+        res.status.should.eql(404);
+        res.body.error.should.eql('No party with such id');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
implement an endpoint that allows an admin to delete a party
#### Description of Task to be completed?
- add a delete party method to the party controller class
#### How should this be manually tested?
- clone the GitHub repo
- checkout branch ``ft-admin-delete-party-163556842``
- on POSTMAN, send a DELETE request to ``/api/v1/parties/<partyId>``.  The response should be a success message with a status code of 200
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163556842
