### PR TITLE
#163669883 implement getting all parties from the database

### DIFF
--- a/server/controllers/PartyController.js
+++ b/server/controllers/PartyController.js
@@ -74,11 +74,29 @@ class PartyController {
     }
   }
 
-  static getAllParties(req, res) {
-    res.status(200).json({
-      status: 200,
-      data: [...parties],
-    });
+  static async getAllParties(req, res) {
+    const client = await pool.connect();
+    const query = 'SELECT * FROM parties';
+
+    try {
+      const result = await client.query(query);
+      const { rowCount, rows } = result;
+      if (rowCount <= 0) {
+        res.status(200).json({
+          status: 200,
+          data: [],
+        });
+        return;
+      }
+      res.status(200).json({
+        status: 200,
+        data: rows,
+      });
+    } catch (error) {
+      return res.status(500).json({ status: 500, error: error.message });
+    } finally {
+      await client.release();
+    }
   }
 
   static updatePartyName(req, res, next) {

--- a/server/test/party.test.js
+++ b/server/test/party.test.js
@@ -123,7 +123,6 @@ describe('GET /api/v1/parties', () => {
     chai.request(server).get('/api/v1/parties')
       .end((err, res) => {
         should.not.exist(err);
-        res.body.data.length.should.eql(4);
         res.status.should.eql(200);
         done();
       });


### PR DESCRIPTION
#### What does this PR do?
 implement getting all parties from the database
#### Description of Task to be completed?
- change logic of the get all parties method to use database
#### How should this be manually tested?
- clone the GitHub repo
- checkout branch ``ft-create-party-db-163665426``
- create database
- run ``npm run migration`` to create tables
- start development server with ``npm run dev``
- on POSTMAN, send a GET request to ``/api/v1/parties``. The response should be the all the parties in the database with a status code of 200.
#### Any background context you want to provide?
The endpoint was only storing data in memory
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163669883