### PR TITLE
#163670091 implement endpoint for creating office

### DIFF
--- a/server/test/office.test.js
+++ b/server/test/office.test.js
@@ -59,7 +59,10 @@ describe('POST /api/v1/offices', () => {
   });
 
   it('should return an error when office name and type already exist', (done) => {
-    chai.request(server).post('/api/v1/offices').send({ type: 'federal', name: 'president' })
+    chai.request(server).post('/api/v1/offices').send({
+      name: 'house of assembly',
+      type: 'state',
+    })
       .end((err, res) => {
         res.status.should.eql(409);
         done();


### PR DESCRIPTION
#### What does this PR do?
implement endpoint for creating an office and storing it in the database
#### Description of Task to be completed?
- change the logic of the create office method to ensure database storage
#### How should this be manually tested?
- clone the GitHub repo
- checkout branch ``ft-create-party-db-163665426``
- create database
- run ``npm run migration`` to create tables
- start development server with ``npm run dev``
- on POSTMAN, send a POST request to ``/api/v1/offices``. Send a post body with name and type as fields. input can only be federal, legislative, state or local government. The response should be the requested party with a status code of 200
#### Any background context you want to provide?
The endpoint was only storing data in memory
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163670091