### PR TITLE
#163670159 implement an endpoint to get a specific office

### DIFF
--- a/server/test/office.test.js
+++ b/server/test/office.test.js
@@ -6,45 +6,6 @@ chai.use(chaiHttp);
 
 const should = chai.should();
 
-describe('GET /api/v1/offices', () => {
-  it('should return all offices', (done) => {
-    chai.request(server).get('/api/v1/offices')
-      .end((err, res) => {
-        res.status.should.eql(200);
-        done();
-      });
-  });
-
-  it('should return a single office', (done) => {
-    chai.request(server).get('/api/v1/offices/1')
-      .end((err, res) => {
-        should.not.exist(err);
-        res.body.data[0].name.should.eql('president');
-        res.status.should.eql(200);
-        done();
-      });
-  });
-
-
-  it('should not return an office if the id is not valid', (done) => {
-    chai.request(server).get('/api/v1/offices/mnbvn')
-      .end((err, res) => {
-        res.status.should.eql(400);
-        res.body.error.should.eql('Invalid id');
-        done();
-      });
-  });
-
-  it('should return an error if there is no office with the id', (done) => {
-    chai.request(server).get('/api/v1/offices/9')
-      .end((err, res) => {
-        res.status.should.eql(404);
-        res.body.error.should.eql('No office with such id');
-        done();
-      });
-  });
-});
-
 describe('POST /api/v1/offices', () => {
   it('should create a new office', (done) => {
     chai.request(server).post('/api/v1/offices').send({
@@ -93,3 +54,43 @@ describe('POST /api/v1/offices', () => {
       });
   });
 });
+
+describe('GET /api/v1/offices', () => {
+  it('should return all offices', (done) => {
+    chai.request(server).get('/api/v1/offices')
+      .end((err, res) => {
+        res.status.should.eql(200);
+        done();
+      });
+  });
+
+  it('should return a single office', (done) => {
+    chai.request(server).get('/api/v1/offices/1')
+      .end((err, res) => {
+        should.not.exist(err);
+        res.status.should.eql(200);
+        done();
+      });
+  });
+
+
+  it('should not return an office if the id is not valid', (done) => {
+    chai.request(server).get('/api/v1/offices/mnbvn')
+      .end((err, res) => {
+        res.status.should.eql(400);
+        res.body.error.should.eql('Invalid id');
+        done();
+      });
+  });
+
+  it('should return an error if there is no office with the id', (done) => {
+    chai.request(server).get('/api/v1/offices/1000')
+      .end((err, res) => {
+        res.status.should.eql(404);
+        res.body.error.should.eql('No office with such id');
+        done();
+      });
+  });
+});
+
+


### PR DESCRIPTION
#### What does this PR do?
Implement an endpoint to get a specific office from the database
#### Description of Task to be completed?
- change logic to allow using database instead of data structures
#### How should this be manually tested?
- clone the GitHub repo
- checkout branch ``ft-create-party-db-163665426``
- create database
- run ``npm run migration`` to create tables
- start development server with ``npm run dev``
- on POSTMAN, send a GET request to ``/api/v1/offices/:officeId``. The response should be the requested office with a status code of 200 
#### Any background context you want to provide?
The endpoint was only storing data in memory
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163670159