### PR TITLE
#163670154 implement endpoint for getting all offices

### DIFF
--- a/server/controllers/OfficeController.js
+++ b/server/controllers/OfficeController.js
@@ -35,11 +35,29 @@ class OfficeController {
     }
   }
 
-  static getAllOffices(req, res, next) {
-    res.status(200).json({
-      status: 200,
-      data: [...offices],
-    });
+  static async getAllOffices(req, res, next) {
+    const client = await pool.connect();
+    const query = 'SELECT * FROM offices';
+
+    try {
+      const result = await client.query(query);
+      const { rowCount, rows } = result;
+      if (rowCount <= 0) {
+        res.status(200).json({
+          status: 200,
+          data: [],
+        });
+        return;
+      }
+      res.status(200).json({
+        status: 200,
+        data: rows,
+      });
+    } catch (error) {
+      return res.status(500).json({ status: 500, error: error.message });
+    } finally {
+      await client.release();
+    }
   }
 
   static async getOneOffice(req, res, next) {


### PR DESCRIPTION
#### What does this PR do?
#### Description of Task to be completed?
- change logic of the get all offices method to ensure data is coming  from the database
#### How should this be manually tested?
- clone the GitHub repo
- checkout branch ``ft-get-all-offices-db-163670154``
- create database
- run ``npm run migration`` to create tables
- start development server with ``npm run dev``
- on POSTMAN, send a GET request to ``/api/v1/parties``. The response should be the all the offices in the database with a status code of 200
#### Any background context you want to provide?
The endpoint was only storing data in memory
#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)