### PR TITLE
#163638090 implement endpoint for registering a user as a candidate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - "stable"
+before_script:
+  - psql -c 'create database politico_test;' -U postgres
+after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # politico
+[![Build Status](https://travis-ci.org/Bobjayafam/politico.svg?branch=develop)](https://travis-ci.org/Bobjayafam/politico) [![Coverage Status](https://coveralls.io/repos/github/Bobjayafam/politico/badge.svg?branch=develop)](https://coveralls.io/github/Bobjayafam/politico?branch=develop) [![Maintainability](https://api.codeclimate.com/v1/badges/35216ddb20be54347494/maintainability)](https://codeclimate.com/github/Bobjayafam/politico/maintainability)
 Politico- A web application that enables citizens give their mandate to politicians running for different government offices while building trust in the process through transparency.
 
 # Features

--- a/server/db/seeds.js
+++ b/server/db/seeds.js
@@ -15,15 +15,37 @@ const isAdmin = process.env.IS_ADMIN;
 const adminPassportUrl = process.env.ADMIN_PASSPORT_URL;
 
 const adminData = [adminFirstname, adminLastname, adminOthername, adminEmail, adminPassword, adminPhoneNumber, isAdmin, adminPassportUrl];
+const userQuery = 'INSERT INTO users(first_name, last_name, other_name, email, password, phone_number, is_admin, passport_url) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)';
+
+const user1 = ['Stanley', 'Obi', 'Abanum', 'stapolly@yahoo.com', Helpers.hashPassword('123456'), '08025862169', false, 'https://res.cloudinary.com/dpuyyqxnl/image/upload/v1549078659/nhqytbpoh9h5ldqpeeed.jpg'];
+
+const user2 = ['George', 'Ugboma', 'Azikiwe', 'georgeeano@yahoo.com', Helpers.hashPassword('123456'), '08034795933', false, 'https://res.cloudinary.com/dpuyyqxnl/image/upload/v1549078659/nhqytbpoh9h5ldqpeeed.jpg'];
+
+const party1 = ['Peoples democratic party', '12 Ozumba mbadiwe street, lagos', 'https://res.cloudinary.com/dpuyyqxnl/image/upload/v1549078659/nhqytbpoh9h5ldqpeeed.jpg', 'PDP'];
+
+const party2 = ['All progressives congress', '12 Ozumba mbadiwe street, lagos', 'https://res.cloudinary.com/dpuyyqxnl/image/upload/v1549078659/nhqytbpoh9h5ldqpeeed.jpg', 'APC'];
+
+const party3 = ['All progressive grand alliance', '12 Ozumba mbadiwe street, lagos', 'https://res.cloudinary.com/dpuyyqxnl/image/upload/v1549078659/nhqytbpoh9h5ldqpeeed.jpg', 'APGA'];
+
+const office1 = ['senate', 'legislative'];
+const office2 = ['governor', 'state'];
+const office3 = ['councillor', 'local government'];
+
+const officeQuery = 'INSERT INTO offices(name, type) VALUES ($1, $2)';
+const partyQuery = 'INSERT INTO parties(name, hq_address, logo_url, acronym) VALUES ($1, $2, $3, $4)';
 
 const seed = async () => {
   const client = await pool.connect();
   try {
-    await client.query(
-      `INSERT INTO users
-        (first_name, last_name, other_name, email, password, phone_number, is_admin, passport_url) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-      `, adminData,
-    );
+    await client.query(userQuery, adminData);
+    await client.query(userQuery, user1);
+    await client.query(userQuery, user2);
+    await client.query(officeQuery, office1);
+    await client.query(officeQuery, office2);
+    await client.query(officeQuery, office3);
+    await client.query(partyQuery, party1);
+    await client.query(partyQuery, party2);
+    await client.query(partyQuery, party3);
   } catch (error) {
     console.log(error);
   } finally {

--- a/server/routes/officesRoute.js
+++ b/server/routes/officesRoute.js
@@ -7,5 +7,6 @@ const router = express.Router();
 router.post('/', Validate.validateOffice, OfficeController.createoffice);
 router.get('/', OfficeController.getAllOffices);
 router.get('/:id', Validate.validateId, OfficeController.getOneOffice);
+router.post('/:id/register', Validate.validateId, OfficeController.registerCandidate);
 
 export default router;

--- a/server/test/auth.test.js
+++ b/server/test/auth.test.js
@@ -7,10 +7,10 @@ chai.use(chaiHttp);
 const should = chai.should();
 
 const newUser = {
-  firstname: 'Stanley',
-  lastname: 'Obi',
-  othername: 'Abanum',
-  email: 'stapolly@yahoo.com',
+  firstname: 'David',
+  lastname: 'Itoadon',
+  othername: 'Omofoma',
+  email: 'pastor_dave@yahoo.com',
   password: '123456',
   phoneNumber: '09034589684',
   passportUrl: 'http://kkssls.jpg',

--- a/server/test/office.test.js
+++ b/server/test/office.test.js
@@ -9,8 +9,8 @@ const should = chai.should();
 describe('POST /api/v1/offices', () => {
   it('should create a new office', (done) => {
     chai.request(server).post('/api/v1/offices').send({
-      name: 'house of assembly',
-      type: 'state',
+      name: 'chairman',
+      type: 'local government',
     })
       .end((err, res) => {
         should.not.exist(err);
@@ -21,8 +21,8 @@ describe('POST /api/v1/offices', () => {
 
   it('should return an error when office name and type already exist', (done) => {
     chai.request(server).post('/api/v1/offices').send({
-      name: 'house of assembly',
-      type: 'state',
+      name: 'chairman',
+      type: 'local government',
     })
       .end((err, res) => {
         res.status.should.eql(409);
@@ -94,3 +94,14 @@ describe('GET /api/v1/offices', () => {
 });
 
 
+describe('POST /api/v1/office/userId/register', () => {
+  it('should register a user as a candidate', (done) => {
+    chai.request(server).post('/api/v1/offices/2/register').send({
+      office: 1,
+      party: 3,
+    }).end((err, res) => {
+      console.log(res.text);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
implement an endpoint for registering a user as a candidate for a specific political office
#### Description of Task to be completed?
- add a register candidate method
- add seed data for easier development workflow
- update  tests
- update readme to show badges
- add database to travis
#### How should this be manually tested?
- clone the GitHub repo
- checkout branch ``ft-create-party-db-163665426``
- create database
- run ``npm run migration`` to create tables and ``npm run seed`` to seed the database
- start development server with ``npm run dev``
- on POSTMAN, send a POST request to ``/api/v1/offices/:userId/register``. The response should be the office id, party id and the candidate id with a status code of 201
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163638090
#### Screenshots (if appropriate)