### PR TITLE
#164016139 fetch edit party name endpoint

### DIFF
--- a/client/edit-party.html
+++ b/client/edit-party.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="stylesheet" href="css/styles.css">
+  <title>Edit Party Details</title>
+</head>
+
+<body>
+  <div class="main-container">
+    <nav class="navbar container">
+      <div class="navbar-brand">
+        <a href="index.html">
+          <img src="assets/images/logo.png" alt="logo">
+        </a>
+      </div>
+      <label class="navbar_toggle" for="toggle">&#9776;</label>
+      <input type="checkbox" id="toggle">
+      <ul class="navbar-menu">
+        <li><a href="admin.html">Dashboard</a></li>
+        <li><a href="create-party.html">Create Party</a></li>
+        <li><a href="create-office.html">Create Office</a></li>
+        <li><a href="login.html">Logout</a></li>
+      </ul>
+
+    </nav>
+    <section class="container mb-10">
+      <div class="intro-text text-center">
+        <h1>EDIT PARTY NAME</h1>
+      </div>
+    </section>
+
+    <div class="signup-container container">
+      <div class="lds-hourglass"></div>
+      <div class="alert-box"></div>
+      <form action="" class="update-form">
+        <div class="input-group">
+          <label for="">Party Name <span>*</span></label>
+          <input type="text" value="" class="party-name" name="name">
+        </div>
+
+        <div class="input-group">
+          <button>Update Party</button>
+        </div>
+      </form>
+    </div>
+
+    <footer class="text-center mt-20">
+      <div class="container">
+        <span>Copyright &copy; 2019 | Politico- An Andela Bootcamp Project</span>
+      </div>
+    </footer>
+  </div>
+
+  <script src="js/edit-party.js"></script>
+</body>
+
+</html>

--- a/client/js/admin.js
+++ b/client/js/admin.js
@@ -10,16 +10,25 @@ if (!isAdmin) {
 
 const createTemplate = (parties) => {
   let template = '';
-  parties.map((party) => {
+  parties.sort((a, b) => {
+    if (a.name > b.name) {
+      return 1;
+    }
+    if (a.name < b.name) {
+      return -1;
+    }
+    return 0;
+  });
+  parties.map((party, index) => {
     template += `
-    <tr>
-      <td data-th="S/N">${party.id}</td>
+    <tr data-id="${party.id}">
+      <td data-th="S/N">${index + 1}</td>
       <td data-th="Party Name">${party.name}</td>
       <td data-th="Acronym">${party.acronym}</td>
       <td data-th="Logo"><img src="${party.logo_url}" alt="logo" class="party-logo"></td>
       <td data-th="Headquarters">${party.hq_address}</td>
       <td data-th="Actions">
-        <button onclick="window.location.href='edit-party.html'">Edit</button>
+        <button class="edit">Edit</button>
         <button class="delete">Delete</button>
       </td>
     </tr>
@@ -46,3 +55,11 @@ const getParties = () => {
 };
 
 getParties();
+
+tableBody.addEventListener('click', (e) => {
+  if (e.target.matches('.edit')) {
+    const partyId = e.target.parentNode.parentNode.dataset.id;
+    const partyName = e.target.parentNode.parentNode.firstChild.nextSibling.nextSibling.nextSibling.textContent;
+    window.location = `edit-party.html?partyName=${partyName}&partyId=${partyId}`;
+  }
+});

--- a/client/js/edit-party.js
+++ b/client/js/edit-party.js
@@ -1,0 +1,94 @@
+const alertBox = document.querySelector('.alert-box');
+const API_URL = 'http://localhost:4000/api/v1/';
+const loggedInUser = JSON.parse(localStorage.getItem('user'));
+const loader = document.querySelector('.lds-hourglass');
+loader.style.display = 'none';
+
+const { token, isAdmin } = loggedInUser;
+
+if (!isAdmin) {
+  window.location.href = 'user.html';
+}
+
+const getQueryStrings = () => {
+  const url = window.location.search;
+  const queryStringsArray = url.substring(url.indexOf('?') + 1).split('&');
+  const queryStrings = {};
+  for (let i = 0; i < queryStringsArray.length; i++) {
+    queryStringsArray[i] = queryStringsArray[i].split('=');
+    queryStrings[queryStringsArray[i][0]] = decodeURIComponent(queryStringsArray[i][1]);
+  }
+  return queryStrings;
+};
+
+const queryStrings = getQueryStrings();
+
+const { partyName, partyId } = queryStrings;
+
+const partyNameField = document.querySelector('.party-name');
+
+partyNameField.value = partyName;
+
+const updateForm = document.querySelector('.update-form');
+
+
+const handleUpdate = (e) => {
+  e.preventDefault();
+  const formData = new FormData(updateForm);
+
+  const name = formData.get('name');
+  let error = '';
+  const errors = [];
+  if (name === '') {
+    error = 'Name cannnot be empty';
+    errors.push(error);
+  }
+
+  if (name && name.trim() === '') {
+    error = 'Name cannnot be empty';
+    errors.push(error);
+  }
+  if (errors.length > 0) {
+    const template = `
+              <ul>
+                ${errors.map(err => `<li class="alert-danger">${err}</li>`).join('')}
+              </ul>
+            `;
+    alertBox.innerHTML = template;
+    setTimeout(() => {
+      alertBox.innerHTML = '';
+    }, 3000);
+  } else {
+    loader.style.display = 'inline-block';
+    const newData = { name };
+    fetch(`${API_URL}parties/${partyId}/name`, {
+      mode: 'cors',
+      method: 'PATCH',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-access-token': token,
+      },
+      body: JSON.stringify(newData),
+    }).then(res => res.json())
+      .then((result) => {
+        loader.style.display = 'none';
+        if (result.status === 200) {
+          const template = `
+              <ul>
+                <li class="alert-success">Party name successfully changed and redirecting to dashboard</li>
+              </ul>
+            `;
+
+          alertBox.innerHTML = template;
+          setTimeout(() => {
+            alertBox.innerHTML = '';
+            window.location.href = 'admin.html';
+          }, 3000);
+        }
+      })
+      .catch(error => console.log(error));
+  }
+};
+
+updateForm.addEventListener('submit', handleUpdate);

--- a/server/controllers/PartyController.js
+++ b/server/controllers/PartyController.js
@@ -43,7 +43,7 @@ class PartyController {
           const { rows } = result;
           if (result.rowCount) {
             return res.status(201).json({
-              status: 200,
+              status: 201,
               data: [{
                 id: rows[0].id,
                 name: rows[0].name,

--- a/server/server.js
+++ b/server/server.js
@@ -15,9 +15,10 @@ const app = express();
 const port = process.env.PORT || 4000;
 
 app.use(logger('dev'));
+app.use(cors());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(cors());
+
 
 app.use('/api/v1', routes);
 


### PR DESCRIPTION
#### What does this PR do?
implement edit party name functionality which allows an admin user to edit a party name and stores the new party name in the database
#### Description of Task to be completed?
- sort parties list alphabetically
- use query strings to store party name and id
- fetch /api/v1/:partyId/name from client
#### How should this be manually tested?
- by visiting the app on GitHub pages, signing in as an admin and trying to edit a party from the admin dashboard.
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/164016139
#### Screenshots (if appropriate)
![edit-party-frontend](https://user-images.githubusercontent.com/19153324/52934898-1bea7680-3358-11e9-9065-89ec988df170.png)
